### PR TITLE
download audio file before transcribe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       }
     },
     "@google-cloud/storage": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.1.2.tgz",
-      "integrity": "sha512-kYP7h2SMx5KmbIbeQ4qHoBm9uYFRZOR96BCYpzGWYO8ii157sA1nmmULai0lcrVwOhfVXoReZUpflTc5lFN80g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.1.3.tgz",
+      "integrity": "sha512-79Ag+4eQq+KFJcKB85AimepoqTJOGuDLAmJd7JkLc8NM12a87JTCoGi65oi1eZ4H77AV0uUQxSS2Fo/hZL3+kQ==",
       "requires": {
         "@google-cloud/common": "^2.1.1",
         "@google-cloud/paginator": "^2.0.0",
@@ -70,7 +70,7 @@
         "arrify": "^2.0.0",
         "compressible": "^2.0.12",
         "concat-stream": "^2.0.0",
-        "date-and-time": "^0.10.0",
+        "date-and-time": "^0.11.0",
         "duplexify": "^3.5.0",
         "extend": "^3.0.2",
         "gaxios": "^2.0.1",
@@ -758,9 +758,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.10.0.tgz",
-      "integrity": "sha512-IbIzxtvK80JZOVsWF6+NOjunTaoFVYxkAQoyzmflJyuRCJAJebehy48mPiCAedcGp4P7/UO3QYRWa0fe6INftg=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.11.0.tgz",
+      "integrity": "sha512-VyzhHurex4wlg9oMszn7O+kxHchphWjzDn7Mv0WfkFKI6hSNOQePpTBFGsnRakvLNzQKXqPBAVV8DOxUGtUxqA=="
     },
     "date-fns": {
       "version": "2.6.0",

--- a/services/ms-speaker-registration.js
+++ b/services/ms-speaker-registration.js
@@ -95,7 +95,7 @@ async function tagTranscription(meetingId, profileIds, transcription) {
                     const audioBlob = fs.readFileSync(`${__appRoot}/tmp/speaker${i + 1}.wav`);
                     const options = {
                         method: 'post',
-                        url: AZURE_ENDPOINT + `/identify?identificationProfileIds=${profileIds.join()}&shortAudio=true`,
+                        url: AZURE_ENDPOINT + `/identify?identificationProfileIds=${profileIds.join()}?shortAudio=true`,
                         data: audioBlob,
                         headers: {
                             'Content-Type': 'application/octet-stream',
@@ -120,7 +120,8 @@ async function tagTranscription(meetingId, profileIds, transcription) {
                             }
                         });
                     } catch (err) {
-                        console.log(`Fail to get who is speaking: ${err}`);
+                        console.log('Fail to get who is speaking:');
+                        console.log(err.response.data);
                     }
                 })
             );

--- a/services/ms-speaker-registration.js
+++ b/services/ms-speaker-registration.js
@@ -95,7 +95,7 @@ async function tagTranscription(meetingId, profileIds, transcription) {
                     const audioBlob = fs.readFileSync(`${__appRoot}/tmp/speaker${i + 1}.wav`);
                     const options = {
                         method: 'post',
-                        url: AZURE_ENDPOINT + `/identify?identificationProfileIds=${profileIds.join()}?shortAudio=true`,
+                        url: AZURE_ENDPOINT + `/identify?identificationProfileIds=${profileIds.join()}&shortAudio=true`,
                         data: audioBlob,
                         headers: {
                             'Content-Type': 'application/octet-stream',

--- a/services/transcribe/audio-trim.js
+++ b/services/transcribe/audio-trim.js
@@ -27,11 +27,11 @@ function mergeDuration(value) {
     }
 }
 
-function splitAudioFileBySpeakers(value, key, readStream) {
+function splitAudioFileBySpeakers(value, key, path) {
     return new Promise((resolve, reject) => {
         for (let i = 0; i < value.length; i++) {
             //console.log(value[i][0]);
-            ffmpeg(readStream)
+            ffmpeg(path)
                 .setStartTime(value[i][0])
                 .setDuration(value[i][1] - value[i][0])
                 .on('error', function (err) {

--- a/services/transcribe/google-speaker-diarization.js
+++ b/services/transcribe/google-speaker-diarization.js
@@ -26,6 +26,10 @@ function createGoogleCloudReadStream(fileName) {
     return storage.bucket(bucketName).file(fileName).createReadStream();
 }
 
+async function downloadFileFromGoogleCloud(fileName, destination) {
+    await storage.bucket(bucketName).file(fileName).download({destination});
+}
+
 async function getUntaggedTranscription(meetingId, speakerCount) {
     const audio = {
         uri: `gs://${bucketName}/${meetingId}`
@@ -86,8 +90,9 @@ async function getUntaggedTranscription(meetingId, speakerCount) {
     });
     speakersAudio.forEach(audioTrim.mergeDuration);
     console.log(speakersAudio);
+    const path = `${__appRoot}/tmp/${meetingId}.wav`;
     for (let [key, value] of speakersAudio) {
-        await audioTrim.splitAudioFileBySpeakers(value, key, createGoogleCloudReadStream(meetingId));
+        await audioTrim.splitAudioFileBySpeakers(value, key, path);
     }
 
     for (let [key, value] of speakersAudio) {
@@ -98,6 +103,7 @@ async function getUntaggedTranscription(meetingId, speakerCount) {
 
 module.exports = {
     getUntaggedTranscription: getUntaggedTranscription,
-    createGoogleCloudWriteStream: createGoogleCloudWriteStream
+    createGoogleCloudWriteStream: createGoogleCloudWriteStream,
+    downloadFileFromGoogleCloud: downloadFileFromGoogleCloud
 };
 

--- a/services/transcribe/transcription.js
+++ b/services/transcribe/transcription.js
@@ -1,5 +1,5 @@
 const { getDatabase } = require('../database');
-const { getUntaggedTranscription } = require('../transcribe/google-speaker-diarization');
+const { getUntaggedTranscription, downloadFileFromGoogleCloud } = require('../transcribe/google-speaker-diarization');
 const { tagTranscription } = require('../ms-speaker-registration');
 const { clearWavFile } = require('./clear-temporary-files');
 const { sendTranscriptionToManager } = require('../outlook/meeting');
@@ -24,6 +24,7 @@ async function startTranscription(meetingId) {
     const meeting = await db.collection('meetings').findOne({meetingId: meetingId});
     const speakerCount = meeting.participants.length - 1; // account for parrot itself
     const profileIds = await getProfileIds(meeting);
+    await downloadFileFromGoogleCloud(meetingId, `${__appRoot}/tmp/${meetingId}.wav`);
     const untaggedTranscription = await getUntaggedTranscription(meetingId, speakerCount);
     await tagTranscription(meetingId, profileIds, untaggedTranscription);
     await sendTranscriptionToManager(meetingId);


### PR DESCRIPTION
It seems like using read stream is the reason of file being not correcly splited. I changed it to download the file from clound and pass the path to ffmpeg(just like before). @Csignore The function to get map of speaker tags and audio durations is fine.